### PR TITLE
add details-bin status trailer to status message featrue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": ">=7.2",
+        "google/common-protos": "^3.2.0",
         "google/protobuf": "^3.6.1"
     },
     "suggest": {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -13,6 +13,7 @@ namespace Hyperf\Grpc;
 
 use Google\Protobuf\GPBEmpty;
 use Google\Protobuf\Internal\Message;
+use Google\Rpc\Status;
 use swoole_http2_response;
 
 class Parser
@@ -99,5 +100,22 @@ class Parser
     private static function isinvalidStatus(int $code)
     {
         return $code !== 0 && $code !== 200 && $code !== 400;
+    }
+
+    /**
+     * @param swoole_http2_response
+     * @return null|Status
+     */
+    public static function statusFromResponse($response): ?Status
+    {
+        $detailsEncoded = $response->headers['grpc-status-details-bin'] ?? '';
+
+        if (!$detailsEncoded || !$detailsBin = base64_decode($detailsEncoded, true)) {
+            return null;
+        } else {
+            $status = new Status();
+            $status->mergeFromString($detailsBin);
+            return $status;
+        }
     }
 }


### PR DESCRIPTION
为Parser类添加解析swoole http2 response头grpc-status-details-bin到[proto.Status message](https://github.com/googleapis/common-protos-php/blob/main/src/Rpc/Status.php)功能